### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,11 @@
 
 # Required
 version: 2
-
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+    
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
@@ -14,7 +18,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt
     - method: pip


### PR DESCRIPTION
RTD requires `build.os` and `build.tools.python` from October on.